### PR TITLE
Use prettier and format some files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Tab indentation
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# The indent size used in the `package.json` file cannot be changed
+# https://github.com/npm/npm/pull/3180#issuecomment-16336516
+[{.travis.yml,npm-shrinkwrap.json,package.json}]
+indent_style = space
+indent_size = 4

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    singleQuote: true,
+    printWidth: 120,
+    tabWidth: 4,
+    endOfLine: 'auto',
+    trailingComma: 'none',
+    overrides: []
+};

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,8 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"dbaeumer.vscode-eslint"
+		"dbaeumer.vscode-eslint",
+        "editorconfig.editorconfig",
+        "esbenp.prettier-vscode",
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,12 +10,25 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
+				"--extensionDevelopmentPath=${workspaceFolder}",
+                "--enable-proposed-api"
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
 			"preLaunchTask": "${defaultBuildTask}"
+		},
+		{
+			"name": "Run Extension (with deemon)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}", "--enable-proposed-api"
+			],
+            "skipFiles": ["<node_internals>/**"],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			]
 		},
 		{
 			"name": "Extension Tests",

--- a/package.json
+++ b/package.json
@@ -1,345 +1,345 @@
 {
-	"name": "vscode-jupyter-powertoys",
-	"displayName": "Jupyter PowerToys",
-	"publisher": "ms-toolsai",
-	"author": {
-		"name": "Microsoft Corporation"
-	},
-	"license": "MIT",
-	"homepage": "https://github.com/Microsoft/vscode-jupyter-powertoys",
-	"description": "Optional, experimental, and advanced features for Jupyter notebook support in VS Code.",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-jupyter-powertoys"
-	},
-	"bugs": {
-		"url": "https://github.com/Microsoft/vscode-jupyter-powertoys/issues"
-	},
-	"qna": "https://github.com/microsoft/vscode-jupyter-powertoys/discussions",
-	"version": "0.0.1",
-	"engines": {
-		"vscode": "^1.65.0"
-	},
-	"extensionDependencies": [
-		"ms-toolsai.jupyter"
-	],
-	"keywords": [
-		"jupyter",
-		"notebook",
-		"ipynb",
-		"execution",
-		"notebookKernelJupyterNotebook"
-	],
-	"categories": [
-		"Other",
-		"Data Science",
-		"Machine Learning",
-		"Notebooks",
-		"Visualization"
-	],
-	"enabledApiProposals": [
-		"notebookEditor",
-		"notebookEditorEdit"
-	],
-	"main": "./out/extension.js",
-	"activationEvents": [
-		"onNotebook:*"
-	],
-	"contributes": {
-		"commands": [
-			{
-				"command": "vscode-notebook-groups.executeGroup1",
-				"title": "Execute Group 1",
-				"category": "Notebook Run Groups",
-				"icon": {
-					"light": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneRun-light.svg",
-					"dark": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneRun-dark.svg"
-				}
-			},
-			{
-				"command": "vscode-notebook-groups.addGroup1",
-				"title": "Add Group 1",
-				"category": "Notebook Run Groups",
-				"icon": {
-					"light": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneAdd-light.svg",
-					"dark": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneAdd-dark.svg"
-				}
-			},
-			{
-				"command": "vscode-notebook-groups.removeGroup1",
-				"title": "Remove Group 1",
-				"category": "Notebook Run Groups",
-				"icon": {
-					"light": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneRemove-light.svg",
-					"dark": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneRemove-dark.svg"
-				}
-			},
-			{
-				"command": "vscode-notebook-groups.executeGroup2",
-				"title": "Execute Group 2",
-				"category": "Notebook Run Groups",
-				"icon": {
-					"light": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRun-light.svg",
-					"dark": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRun-dark.svg"
-				}
-			},
-			{
-				"command": "vscode-notebook-groups.addGroup2",
-				"title": "Add Group 2",
-				"category": "Notebook Run Groups",
-				"icon": {
-					"light": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoAdd-light.svg",
-					"dark": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoAdd-dark.svg"
-				}
-			},
-			{
-				"command": "vscode-notebook-groups.removeGroup2",
-				"title": "Remove Group 2",
-				"category": "Notebook Run Groups",
-				"icon": {
-					"light": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRemove-light.svg",
-					"dark": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRemove-dark.svg"
-				}
-			},
-			{
-				"command": "vscode-notebook-groups.executeGroup3",
-				"title": "Execute Group 3",
-				"category": "Notebook Run Groups",
-				"icon": {
-					"light": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRun-light.svg",
-					"dark": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRun-dark.svg"
-				}
-			},
-			{
-				"command": "vscode-notebook-groups.addGroup3",
-				"title": "Add Group 3",
-				"category": "Notebook Run Groups",
-				"icon": {
-					"light": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeAdd-light.svg",
-					"dark": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeAdd-dark.svg"
-				}
-			},
-			{
-				"command": "vscode-notebook-groups.removeGroup3",
-				"title": "Remove Group 3",
-				"category": "Notebook Run Groups",
-				"icon": {
-					"light": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRemove-light.svg",
-					"dark": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRemove-dark.svg"
-				}
-			}
-		],
-		"menus": {
-			"commandPalette": [
-				{
-					"command": "vscode-notebook-groups.executeGroup1",
-					"group": "Notebook Run Groups",
-					"when": "config.notebookRunGroups.groupCount > 0 && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.addGroup1",
-					"group": "Notebook Run Groups",
-					"when": "config.notebookRunGroups.groupCount > 0 && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.removeGroup1",
-					"group": "Notebook Run Groups",
-					"when": "config.notebookRunGroups.groupCount > 0 && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.executeGroup2",
-					"group": "Notebook Run Groups",
-					"when": "config.notebookRunGroups.groupCount > 1 && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.addGroup2",
-					"group": "Notebook Run Groups",
-					"when": "config.notebookRunGroups.groupCount > 1 && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.removeGroup2",
-					"group": "Notebook Run Groups",
-					"when": "config.notebookRunGroups.groupCount > 1 && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.executeGroup3",
-					"group": "Notebook Run Groups",
-					"when": "config.notebookRunGroups.groupCount > 2 && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.addGroup3",
-					"group": "Notebook Run Groups",
-					"when": "config.notebookRunGroups.groupCount > 2 && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.removeGroup3",
-					"group": "Notebook Run Groups",
-					"when": "config.notebookRunGroups.groupCount > 2 && config.notebookRunGroups.enabled"
-				}
-			],
-			"notebook/toolbar": [
-				{
-					"command": "vscode-notebook-groups.executeGroup1",
-					"group": "navigation/execute@6",
-					"when": "config.notebookRunGroups.groupCount > 0 && config.notebookRunGroups.runIconsOnEditorToolbar && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.executeGroup2",
-					"group": "navigation/execute@7",
-					"when": "config.notebookRunGroups.groupCount > 1 && config.notebookRunGroups.runIconsOnEditorToolbar && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.executeGroup3",
-					"group": "navigation/execute@8",
-					"when": "config.notebookRunGroups.groupCount > 2 && config.notebookRunGroups.runIconsOnEditorToolbar && config.notebookRunGroups.enabled"
-				}
-			],
-			"notebook/cell/title": [
-				{
-					"command": "vscode-notebook-groups.addGroup1",
-					"group": "inline/cell@10",
-					"when": "config.notebookRunGroups.groupCount > 0 && !notebookRunGroups.inGroupOne && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.removeGroup1",
-					"group": "inline/cell@11",
-					"when": "config.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.executeGroup1",
-					"group": "inline/cell@12",
-					"when": "config.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.notebookRunGroups.runIconsOnCell && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.addGroup2",
-					"group": "inline/cell@13",
-					"when": "config.notebookRunGroups.groupCount > 1 && !notebookRunGroups.inGroupTwo && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.removeGroup2",
-					"group": "inline/cell@14",
-					"when": "config.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.executeGroup2",
-					"group": "inline/cell@15",
-					"when": "config.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.notebookRunGroups.runIconsOnCell && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.addGroup3",
-					"group": "inline/cell@16",
-					"when": "config.notebookRunGroups.groupCount > 2 && !notebookRunGroups.inGroupThree && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.removeGroup3",
-					"group": "inline/cell@17",
-					"when": "config.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.executeGroup3",
-					"group": "inline/cell@18",
-					"when": "config.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.notebookRunGroups.runIconsOnCell && config.notebookRunGroups.enabled"
-				}
-			],
-			"notebook/cell/execute": [
-				{
-					"command": "vscode-notebook-groups.executeGroup1",
-					"when": "config.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.executeGroup2",
-					"when": "config.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.executeGroup3",
-					"when": "config.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
-				}
-			],
-			"notebook/cell/executePrimary": [
-				{
-					"command": "vscode-notebook-groups.executeGroup1",
-					"when": "config.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.executeGroup2",
-					"when": "config.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
-				},
-				{
-					"command": "vscode-notebook-groups.executeGroup3",
-					"when": "config.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
-				}
-			]
-		},
-		"configuration": [
-			{
-				"type": "object",
-				"title": "NotebookRunGroups",
-				"properties": {
-					"notebookRunGroups.enabled": {
-						"type": "boolean",
-						"default": true,
-						"description": "Enable the notebook run groups feature to provide commands to run groups of notebook cells.",
-						"scope": "machine"
-					},
-					"notebookRunGroups.groupCount": {
-						"type": "integer",
-						"enum": [
-							0,
-							1,
-							2,
-							3
-						],
-						"default": 3,
-						"description": "Count of run groups to show (0-3).",
-						"scope": "machine"
-					},
-					"notebookRunGroups.runIconsOnCell": {
-						"type": "boolean",
-						"default": false,
-						"description": "Display group run icons on each cell toolbar.",
-						"scope": "machine"
-					},
-					"notebookRunGroups.runIconsOnEditorToolbar": {
-						"type": "boolean",
-						"default": true,
-						"description": "Display group run icons on the global notebook editor toolbar.",
-						"scope": "machine"
-					},
-					"notebookRunGroups.runIconsInExecute": {
-						"type": "boolean",
-						"default": true,
-						"description": "Display group run icons in the cell execute dropdown.",
-						"scope": "machine"
-					}
-				}
-			}
-		]
-	},
-	"scripts": {
-		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -p ./",
-		"watch": "tsc -watch -p ./",
-		"pretest": "npm run compile && npm run lint",
-		"lint": "eslint src --ext ts",
-		"test": "node ./out/test/runTest.js",
-		"postinstall": "npm run download-api",
-		"download-api": "vscode-dts dev",
-		"postdownload-api": "vscode-dts main",
-		"compiled": "deemon npm run compile",
-		"kill-compiled": "deemon --kill npm run compile"
-	},
-	"devDependencies": {
-		"@types/glob": "^7.1.4",
-		"@types/mocha": "^9.0.0",
-		"@types/node": "16.11.07",
-		"@typescript-eslint/eslint-plugin": "^5.1.0",
-		"@typescript-eslint/parser": "^5.1.0",
-		"@vscode/test-electron": "^1.6.2",
-		"deemon": "^1.6.0",
-		"eslint": "^8.1.0",
-		"glob": "^7.1.7",
-		"mocha": "^9.1.3",
-		"typescript": "^4.4.4",
-		"vscode-dts": "^0.3.3"
-	}
+    "name": "vscode-jupyter-powertoys",
+    "displayName": "Jupyter PowerToys",
+    "publisher": "ms-toolsai",
+    "author": {
+        "name": "Microsoft Corporation"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Microsoft/vscode-jupyter-powertoys",
+    "description": "Optional, experimental, and advanced features for Jupyter notebook support in VS Code.",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/vscode-jupyter-powertoys"
+    },
+    "bugs": {
+        "url": "https://github.com/Microsoft/vscode-jupyter-powertoys/issues"
+    },
+    "qna": "https://github.com/microsoft/vscode-jupyter-powertoys/discussions",
+    "version": "0.0.1",
+    "engines": {
+        "vscode": "^1.65.0"
+    },
+    "extensionDependencies": [
+        "ms-toolsai.jupyter"
+    ],
+    "keywords": [
+        "jupyter",
+        "notebook",
+        "ipynb",
+        "execution",
+        "notebookKernelJupyterNotebook"
+    ],
+    "categories": [
+        "Other",
+        "Data Science",
+        "Machine Learning",
+        "Notebooks",
+        "Visualization"
+    ],
+    "enabledApiProposals": [
+        "notebookEditor",
+        "notebookEditorEdit"
+    ],
+    "main": "./out/extension.js",
+    "activationEvents": [
+        "onNotebook:*"
+    ],
+    "contributes": {
+        "commands": [
+            {
+                "command": "vscode-notebook-groups.executeGroup1",
+                "title": "Execute Group 1",
+                "category": "Notebook Run Groups",
+                "icon": {
+                    "light": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneRun-light.svg",
+                    "dark": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneRun-dark.svg"
+                }
+            },
+            {
+                "command": "vscode-notebook-groups.addGroup1",
+                "title": "Add Group 1",
+                "category": "Notebook Run Groups",
+                "icon": {
+                    "light": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneAdd-light.svg",
+                    "dark": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneAdd-dark.svg"
+                }
+            },
+            {
+                "command": "vscode-notebook-groups.removeGroup1",
+                "title": "Remove Group 1",
+                "category": "Notebook Run Groups",
+                "icon": {
+                    "light": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneRemove-light.svg",
+                    "dark": "src/notebookRunGroups/icons/RunGroupOne/RunGroupOneRemove-dark.svg"
+                }
+            },
+            {
+                "command": "vscode-notebook-groups.executeGroup2",
+                "title": "Execute Group 2",
+                "category": "Notebook Run Groups",
+                "icon": {
+                    "light": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRun-light.svg",
+                    "dark": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRun-dark.svg"
+                }
+            },
+            {
+                "command": "vscode-notebook-groups.addGroup2",
+                "title": "Add Group 2",
+                "category": "Notebook Run Groups",
+                "icon": {
+                    "light": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoAdd-light.svg",
+                    "dark": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoAdd-dark.svg"
+                }
+            },
+            {
+                "command": "vscode-notebook-groups.removeGroup2",
+                "title": "Remove Group 2",
+                "category": "Notebook Run Groups",
+                "icon": {
+                    "light": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRemove-light.svg",
+                    "dark": "src/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRemove-dark.svg"
+                }
+            },
+            {
+                "command": "vscode-notebook-groups.executeGroup3",
+                "title": "Execute Group 3",
+                "category": "Notebook Run Groups",
+                "icon": {
+                    "light": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRun-light.svg",
+                    "dark": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRun-dark.svg"
+                }
+            },
+            {
+                "command": "vscode-notebook-groups.addGroup3",
+                "title": "Add Group 3",
+                "category": "Notebook Run Groups",
+                "icon": {
+                    "light": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeAdd-light.svg",
+                    "dark": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeAdd-dark.svg"
+                }
+            },
+            {
+                "command": "vscode-notebook-groups.removeGroup3",
+                "title": "Remove Group 3",
+                "category": "Notebook Run Groups",
+                "icon": {
+                    "light": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRemove-light.svg",
+                    "dark": "src/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRemove-dark.svg"
+                }
+            }
+        ],
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "vscode-notebook-groups.executeGroup1",
+                    "group": "Notebook Run Groups",
+                    "when": "config.notebookRunGroups.groupCount > 0 && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.addGroup1",
+                    "group": "Notebook Run Groups",
+                    "when": "config.notebookRunGroups.groupCount > 0 && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.removeGroup1",
+                    "group": "Notebook Run Groups",
+                    "when": "config.notebookRunGroups.groupCount > 0 && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.executeGroup2",
+                    "group": "Notebook Run Groups",
+                    "when": "config.notebookRunGroups.groupCount > 1 && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.addGroup2",
+                    "group": "Notebook Run Groups",
+                    "when": "config.notebookRunGroups.groupCount > 1 && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.removeGroup2",
+                    "group": "Notebook Run Groups",
+                    "when": "config.notebookRunGroups.groupCount > 1 && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.executeGroup3",
+                    "group": "Notebook Run Groups",
+                    "when": "config.notebookRunGroups.groupCount > 2 && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.addGroup3",
+                    "group": "Notebook Run Groups",
+                    "when": "config.notebookRunGroups.groupCount > 2 && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.removeGroup3",
+                    "group": "Notebook Run Groups",
+                    "when": "config.notebookRunGroups.groupCount > 2 && config.notebookRunGroups.enabled"
+                }
+            ],
+            "notebook/toolbar": [
+                {
+                    "command": "vscode-notebook-groups.executeGroup1",
+                    "group": "navigation/execute@6",
+                    "when": "config.notebookRunGroups.groupCount > 0 && config.notebookRunGroups.runIconsOnEditorToolbar && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.executeGroup2",
+                    "group": "navigation/execute@7",
+                    "when": "config.notebookRunGroups.groupCount > 1 && config.notebookRunGroups.runIconsOnEditorToolbar && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.executeGroup3",
+                    "group": "navigation/execute@8",
+                    "when": "config.notebookRunGroups.groupCount > 2 && config.notebookRunGroups.runIconsOnEditorToolbar && config.notebookRunGroups.enabled"
+                }
+            ],
+            "notebook/cell/title": [
+                {
+                    "command": "vscode-notebook-groups.addGroup1",
+                    "group": "inline/cell@10",
+                    "when": "config.notebookRunGroups.groupCount > 0 && !notebookRunGroups.inGroupOne && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.removeGroup1",
+                    "group": "inline/cell@11",
+                    "when": "config.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.executeGroup1",
+                    "group": "inline/cell@12",
+                    "when": "config.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.notebookRunGroups.runIconsOnCell && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.addGroup2",
+                    "group": "inline/cell@13",
+                    "when": "config.notebookRunGroups.groupCount > 1 && !notebookRunGroups.inGroupTwo && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.removeGroup2",
+                    "group": "inline/cell@14",
+                    "when": "config.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.executeGroup2",
+                    "group": "inline/cell@15",
+                    "when": "config.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.notebookRunGroups.runIconsOnCell && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.addGroup3",
+                    "group": "inline/cell@16",
+                    "when": "config.notebookRunGroups.groupCount > 2 && !notebookRunGroups.inGroupThree && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.removeGroup3",
+                    "group": "inline/cell@17",
+                    "when": "config.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.executeGroup3",
+                    "group": "inline/cell@18",
+                    "when": "config.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.notebookRunGroups.runIconsOnCell && config.notebookRunGroups.enabled"
+                }
+            ],
+            "notebook/cell/execute": [
+                {
+                    "command": "vscode-notebook-groups.executeGroup1",
+                    "when": "config.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.executeGroup2",
+                    "when": "config.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.executeGroup3",
+                    "when": "config.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
+                }
+            ],
+            "notebook/cell/executePrimary": [
+                {
+                    "command": "vscode-notebook-groups.executeGroup1",
+                    "when": "config.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.executeGroup2",
+                    "when": "config.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
+                },
+                {
+                    "command": "vscode-notebook-groups.executeGroup3",
+                    "when": "config.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.notebookRunGroups.runIconsInExecute && config.notebookRunGroups.enabled"
+                }
+            ]
+        },
+        "configuration": [
+            {
+                "type": "object",
+                "title": "NotebookRunGroups",
+                "properties": {
+                    "notebookRunGroups.enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Enable the notebook run groups feature to provide commands to run groups of notebook cells.",
+                        "scope": "machine"
+                    },
+                    "notebookRunGroups.groupCount": {
+                        "type": "integer",
+                        "enum": [
+                            0,
+                            1,
+                            2,
+                            3
+                        ],
+                        "default": 3,
+                        "description": "Count of run groups to show (0-3).",
+                        "scope": "machine"
+                    },
+                    "notebookRunGroups.runIconsOnCell": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Display group run icons on each cell toolbar.",
+                        "scope": "machine"
+                    },
+                    "notebookRunGroups.runIconsOnEditorToolbar": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Display group run icons on the global notebook editor toolbar.",
+                        "scope": "machine"
+                    },
+                    "notebookRunGroups.runIconsInExecute": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Display group run icons in the cell execute dropdown.",
+                        "scope": "machine"
+                    }
+                }
+            }
+        ]
+    },
+    "scripts": {
+        "vscode:prepublish": "npm run compile",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./",
+        "pretest": "npm run compile && npm run lint",
+        "lint": "eslint src --ext ts",
+        "test": "node ./out/test/runTest.js",
+        "postinstall": "npm run download-api",
+        "download-api": "vscode-dts dev",
+        "postdownload-api": "vscode-dts main",
+        "compiled": "deemon npm run watch",
+        "kill-compiled": "deemon --kill npm run watch"
+    },
+    "devDependencies": {
+        "@types/glob": "^7.1.4",
+        "@types/mocha": "^9.0.0",
+        "@types/node": "16.11.07",
+        "@typescript-eslint/eslint-plugin": "^5.1.0",
+        "@typescript-eslint/parser": "^5.1.0",
+        "@vscode/test-electron": "^1.6.2",
+        "deemon": "^1.6.0",
+        "eslint": "^8.1.0",
+        "glob": "^7.1.7",
+        "mocha": "^9.1.3",
+        "typescript": "^4.4.4",
+        "vscode-dts": "^0.3.3"
+    }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "ES2020",
         "outDir": "out",
-        "lib": ["dom", "ES2020"],
+        "lib": ["ES2020"],
         "sourceMap": true,
         "rootDir": "src",
         "strict": true /* enable all strict type-checking options */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,16 @@
 {
-	"compilerOptions": {
-		"module": "commonjs",
-		"target": "ES2020",
-		"outDir": "out",
-		"lib": [
-			"ES2020"
-		],
-		"sourceMap": true,
-		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
-		/* Additional Checks */
-		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
-		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
-	},
-	"exclude": [
-		"node_modules",
-		".vscode-test"
-	]
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "ES2020",
+        "outDir": "out",
+        "lib": ["dom", "ES2020"],
+        "sourceMap": true,
+        "rootDir": "src",
+        "strict": true /* enable all strict type-checking options */
+        /* Additional Checks */
+        // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+        // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+        // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+    },
+    "exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
When opening files like package.json or launch.json i found that a lot of the file was changing unnecessarily.
Found this was because we didn't have a consistent tab size.
I know we don't want to enforce any standards in this repo, however I think this is an exception.
Basically this avoids unnecessary changes to the files & fewer changes when submitting PRs.

Again, there's no CI check to enforce this (hence we're not enforcing a standard), if however you have the prettier and editor config extensions installed, then the same white space will be used (resulting in fewer unnecessary changes to files when submitting PRs)