### PR TITLE
Add dependency required by lumino

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -677,6 +677,12 @@
 				"which": "^2.0.1"
 			}
 		},
+		"crypto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+			"integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+			"dev": true
+		},
 		"debug": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -427,6 +427,7 @@
         "@typescript-eslint/eslint-plugin": "^5.1.0",
         "@typescript-eslint/parser": "^5.1.0",
         "@vscode/test-electron": "^1.6.2",
+        "crypto": "^1.0.1",
         "deemon": "^1.6.0",
         "eslint": "^8.1.0",
         "glob": "^7.1.7",


### PR DESCRIPTION
Found this in the demo today, the package.json was missing a dependency required by lumino (which is pulled in my Jupyter services)