### PR TITLE
Bump engine (for proposed API access)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "qna": "https://github.com/microsoft/vscode-jupyter-powertoys/discussions",
     "version": "0.0.1",
     "engines": {
-        "vscode": "^1.65.0"
+        "vscode": "^1.67.0"
     },
     "extensionDependencies": [
         "ms-toolsai.jupyter"


### PR DESCRIPTION
Technically the APIs that this uses have been around for a while. But only version 1.67 and up will actually have the access to the proposed API that I added. So require vscode 1.67 or up to make sure that it runs out of box fine with VS Code.