### PR TITLE
Update run group context keys for new cell resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
                 "icon": {
                     "light": "images/notebookRunGroups/icons/RunGroupOne/RunGroupOneRun-light.svg",
                     "dark": "images/notebookRunGroups/icons/RunGroupOne/RunGroupOneRun-dark.svg"
-                }
+                },
+                "enablement": "notebookRunGroups.groupOneActive"
             },
             {
                 "command": "vscode-notebook-groups.addGroup1",
@@ -89,7 +90,8 @@
                 "icon": {
                     "light": "images/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRun-light.svg",
                     "dark": "images/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRun-dark.svg"
-                }
+                },
+                "enablement": "notebookRunGroups.groupTwoActive"
             },
             {
                 "command": "vscode-notebook-groups.addGroup2",
@@ -116,7 +118,8 @@
                 "icon": {
                     "light": "images/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRun-light.svg",
                     "dark": "images/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRun-dark.svg"
-                }
+                },
+                "enablement": "notebookRunGroups.groupThreeActive"
             },
             {
                 "command": "vscode-notebook-groups.addGroup3",
@@ -299,7 +302,8 @@
                 {
                     "command": "vscode-notebook-groups.executeGroup1",
                     "group": "inline/cell@12",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.jupyter.notebookRunGroups.runIconsOnCell && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.jupyter.notebookRunGroups.runIconsOnCell && config.jupyter.notebookRunGroups.enabled",
+                    "enablement": "notebookRunGroups.groupOneActive"
                 },
                 {
                     "command": "vscode-notebook-groups.addGroup2",
@@ -333,20 +337,6 @@
                 }
             ],
             "notebook/cell/execute": [
-                {
-                    "command": "vscode-notebook-groups.executeGroup1",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.jupyter.notebookRunGroups.runIconsInExecute && config.jupyter.notebookRunGroups.enabled"
-                },
-                {
-                    "command": "vscode-notebook-groups.executeGroup2",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.jupyter.notebookRunGroups.runIconsInExecute && config.jupyter.notebookRunGroups.enabled"
-                },
-                {
-                    "command": "vscode-notebook-groups.executeGroup3",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.jupyter.notebookRunGroups.runIconsInExecute && config.jupyter.notebookRunGroups.enabled"
-                }
-            ],
-            "notebook/cell/executePrimary": [
                 {
                     "command": "vscode-notebook-groups.executeGroup1",
                     "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.jupyter.notebookRunGroups.runIconsInExecute && config.jupyter.notebookRunGroups.enabled"

--- a/package.json
+++ b/package.json
@@ -292,62 +292,62 @@
                 {
                     "command": "vscode-notebook-groups.addGroup1",
                     "group": "inline/cell@10",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && !notebookRunGroups.inGroupOne && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookCellResource not in notebookRunGroups.groupOneCells && config.jupyter.notebookRunGroups.enabled"
                 },
                 {
                     "command": "vscode-notebook-groups.removeGroup1",
                     "group": "inline/cell@11",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookCellResource in notebookRunGroups.groupOneCells && config.jupyter.notebookRunGroups.enabled"
                 },
                 {
                     "command": "vscode-notebook-groups.executeGroup1",
                     "group": "inline/cell@12",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.jupyter.notebookRunGroups.runIconsOnCell && config.jupyter.notebookRunGroups.enabled",
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookCellResource in notebookRunGroups.groupOneCells && config.jupyter.notebookRunGroups.runIconsOnCell && config.jupyter.notebookRunGroups.enabled",
                     "enablement": "notebookRunGroups.groupOneActive"
                 },
                 {
                     "command": "vscode-notebook-groups.addGroup2",
                     "group": "inline/cell@13",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 1 && !notebookRunGroups.inGroupTwo && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 1 && notebookCellResource not in notebookRunGroups.groupTwoCells && config.jupyter.notebookRunGroups.enabled"
                 },
                 {
                     "command": "vscode-notebook-groups.removeGroup2",
                     "group": "inline/cell@14",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 1 && notebookCellResource in notebookRunGroups.groupTwoCells && config.jupyter.notebookRunGroups.enabled"
                 },
                 {
                     "command": "vscode-notebook-groups.executeGroup2",
                     "group": "inline/cell@15",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.jupyter.notebookRunGroups.runIconsOnCell && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 1 && notebookCellResource in notebookRunGroups.groupTwoCells && config.jupyter.notebookRunGroups.runIconsOnCell && config.jupyter.notebookRunGroups.enabled"
                 },
                 {
                     "command": "vscode-notebook-groups.addGroup3",
                     "group": "inline/cell@16",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 2 && !notebookRunGroups.inGroupThree && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 2 && notebookCellResource not in notebookRunGroups.groupThreeCells && config.jupyter.notebookRunGroups.enabled"
                 },
                 {
                     "command": "vscode-notebook-groups.removeGroup3",
                     "group": "inline/cell@17",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 2 && notebookCellResource in notebookRunGroups.groupThreeCells && config.jupyter.notebookRunGroups.enabled"
                 },
                 {
                     "command": "vscode-notebook-groups.executeGroup3",
                     "group": "inline/cell@18",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.jupyter.notebookRunGroups.runIconsOnCell && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 2 && notebookCellResource in notebookRunGroups.groupThreeCells && config.jupyter.notebookRunGroups.runIconsOnCell && config.jupyter.notebookRunGroups.enabled"
                 }
             ],
             "notebook/cell/execute": [
                 {
                     "command": "vscode-notebook-groups.executeGroup1",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookRunGroups.inGroupOne && config.jupyter.notebookRunGroups.runIconsInExecute && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookCellResource in notebookRunGroups.groupOneCells && config.jupyter.notebookRunGroups.runIconsInExecute && config.jupyter.notebookRunGroups.enabled"
                 },
                 {
                     "command": "vscode-notebook-groups.executeGroup2",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 1 && notebookRunGroups.inGroupTwo && config.jupyter.notebookRunGroups.runIconsInExecute && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 1 && notebookCellResource in notebookRunGroups.groupTwoCells && config.jupyter.notebookRunGroups.runIconsInExecute && config.jupyter.notebookRunGroups.enabled"
                 },
                 {
                     "command": "vscode-notebook-groups.executeGroup3",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 2 && notebookRunGroups.inGroupThree && config.jupyter.notebookRunGroups.runIconsInExecute && config.jupyter.notebookRunGroups.enabled"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 2 && notebookCellResource in notebookRunGroups.groupThreeCells && config.jupyter.notebookRunGroups.runIconsInExecute && config.jupyter.notebookRunGroups.enabled"
                 }
             ],
             "view/title": [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
                     "light": "images/notebookRunGroups/icons/RunGroupOne/RunGroupOneRun-light.svg",
                     "dark": "images/notebookRunGroups/icons/RunGroupOne/RunGroupOneRun-dark.svg"
                 },
-                "enablement": "notebookRunGroups.groupOneActive"
+                "enablement": "resource in notebookRunGroups.groupOneDocuments"
             },
             {
                 "command": "vscode-notebook-groups.addGroup1",
@@ -91,7 +91,7 @@
                     "light": "images/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRun-light.svg",
                     "dark": "images/notebookRunGroups/icons/RunGroupTwo/RunGroupTwoRun-dark.svg"
                 },
-                "enablement": "notebookRunGroups.groupTwoActive"
+                "enablement": "resource in notebookRunGroups.groupTwoDocuments"
             },
             {
                 "command": "vscode-notebook-groups.addGroup2",
@@ -119,7 +119,7 @@
                     "light": "images/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRun-light.svg",
                     "dark": "images/notebookRunGroups/icons/RunGroupThree/RunGroupThreeRun-dark.svg"
                 },
-                "enablement": "notebookRunGroups.groupThreeActive"
+                "enablement": "resource in notebookRunGroups.groupThreeDocuments"
             },
             {
                 "command": "vscode-notebook-groups.addGroup3",
@@ -302,8 +302,7 @@
                 {
                     "command": "vscode-notebook-groups.executeGroup1",
                     "group": "inline/cell@12",
-                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookCellResource in notebookRunGroups.groupOneCells && config.jupyter.notebookRunGroups.runIconsOnCell && config.jupyter.notebookRunGroups.enabled",
-                    "enablement": "notebookRunGroups.groupOneActive"
+                    "when": "config.jupyter.notebookRunGroups.groupCount > 0 && notebookCellResource in notebookRunGroups.groupOneCells && config.jupyter.notebookRunGroups.runIconsOnCell && config.jupyter.notebookRunGroups.enabled"
                 },
                 {
                     "command": "vscode-notebook-groups.addGroup2",

--- a/src/notebookRunGroups/TODO.md
+++ b/src/notebookRunGroups/TODO.md
@@ -9,7 +9,8 @@
 - [ ] Clean up TODOs
 - [x] Consolidated run button
 - [x] Use cell status to show group membership
-- [ ] Restrict when command palette commands show up
+- [x] Restrict when command palette commands show up
+- [x] Adopt new context key support for cell resources
 - [ ] Basic VS Code tests
 - [ ] Cleanup README and skeleton code
 - [ ] Release on marketplace

--- a/src/notebookRunGroups/contextKeys.ts
+++ b/src/notebookRunGroups/contextKeys.ts
@@ -19,13 +19,17 @@ export function updateContextKeys() {
     let activeGroup2 = false;
     let activeGroup3 = false;
 
+    // Scan visible notebooks
     vscode.window.visibleNotebookEditors.forEach((notebookEditor) => {
         notebookEditor.notebook.getCells().forEach((cell) => {
+            // Check each cell for group membership and assign it to any group buckets
             const cellGroups = getCellRunGroupMetadata(cell);
 
             if (cellGroups.includes(RunGroup.one.toString())) {
                 group1Cells.push(cell.document.uri);
                 if (notebookEditor === vscode.window.activeNotebookEditor) {
+                    // We want to know if any cells in the active editor are in groups to
+                    // enable non-cell specific UI
                     activeGroup1 = true;
                 }
             }
@@ -51,27 +55,4 @@ export function updateContextKeys() {
     vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupTwoActive', activeGroup2);
     vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupThreeCells', group3Cells);
     vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupThreeActive', activeGroup3);
-}
-
-// Add the specified cell to and out of any group context keys
-function setCellContextKeys(cell: vscode.NotebookCell) {
-    const currentValue = getCellRunGroupMetadata(cell);
-
-    if (currentValue.includes('1')) {
-        vscode.commands.executeCommand('setContext', 'notebookRunGroups.inGroupOne', true);
-    } else {
-        vscode.commands.executeCommand('setContext', 'notebookRunGroups.inGroupOne', false);
-    }
-
-    if (currentValue.includes('2')) {
-        vscode.commands.executeCommand('setContext', 'notebookRunGroups.inGroupTwo', true);
-    } else {
-        vscode.commands.executeCommand('setContext', 'notebookRunGroups.inGroupTwo', false);
-    }
-
-    if (currentValue.includes('3')) {
-        vscode.commands.executeCommand('setContext', 'notebookRunGroups.inGroupThree', true);
-    } else {
-        vscode.commands.executeCommand('setContext', 'notebookRunGroups.inGroupThree', false);
-    }
 }

--- a/src/notebookRunGroups/contextKeys.ts
+++ b/src/notebookRunGroups/contextKeys.ts
@@ -1,19 +1,56 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import * as vscode from 'vscode';
+import { RunGroup } from './enums';
 import { getCellRunGroupMetadata } from './util/cellMetadataHelpers';
 
-// To work around some issues with context keys I'm only considering the currently selected cell for
-// determining if I should show the remove or add buttons for each group. Long term I don't like this
-// solution though, so looking for a way around it
+// Note, this scans all open notebook editors when run, the operation should be very quick so this feels clean
+// and it's only triggered on more explicit user actions (doc open, metadata update) but can always
+// revisit for perf inefficency
 export function updateContextKeys() {
-    const activeSelections = vscode.window.activeNotebookEditor?.selections;
+    // Create our groups for what cells are in each run group
+    const group1Cells: vscode.Uri[] = [];
+    const group2Cells: vscode.Uri[] = [];
+    const group3Cells: vscode.Uri[] = [];
+    
+    // Track if the active notebook document has available groups for the top level menu commands
+    // as we only want those to be enable if there is something in the active document to run
+    let activeGroup1 = false;
+    let activeGroup2 = false;
+    let activeGroup3 = false;
 
-    if (activeSelections?.length) {
-        const activeSelection = activeSelections[0];
-        const activeCell = vscode.window.activeNotebookEditor?.notebook.cellAt(activeSelection.start);
-        activeCell && setCellContextKeys(activeCell);
-    }
+    vscode.window.visibleNotebookEditors.forEach((notebookEditor) => {
+        notebookEditor.notebook.getCells().forEach((cell) => {
+            const cellGroups = getCellRunGroupMetadata(cell);
+
+            if (cellGroups.includes(RunGroup.one.toString())) {
+                group1Cells.push(cell.document.uri);
+                if (notebookEditor === vscode.window.activeNotebookEditor) {
+                    activeGroup1 = true;
+                }
+            }
+            if (cellGroups.includes(RunGroup.two.toString())) {
+                group2Cells.push(cell.document.uri);
+                if (notebookEditor === vscode.window.activeNotebookEditor) {
+                    activeGroup2 = true;
+                }
+            }
+            if (cellGroups.includes(RunGroup.three.toString())) {
+                group3Cells.push(cell.document.uri);
+                if (notebookEditor === vscode.window.activeNotebookEditor) {
+                    activeGroup3 = true;
+                }
+            }
+        });
+    });
+
+    // Set the actual contexts
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupOneCells', group1Cells);
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupOneActive', activeGroup1);
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupTwoCells', group2Cells);
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupTwoActive', activeGroup2);
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupThreeCells', group3Cells);
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupThreeActive', activeGroup3);
 }
 
 // Add the specified cell to and out of any group context keys

--- a/src/notebookRunGroups/contextKeys.ts
+++ b/src/notebookRunGroups/contextKeys.ts
@@ -9,50 +9,41 @@ import { getCellRunGroupMetadata } from './util/cellMetadataHelpers';
 // revisit for perf inefficency
 export function updateContextKeys() {
     // Create our groups for what cells are in each run group
-    const group1Cells: vscode.Uri[] = [];
-    const group2Cells: vscode.Uri[] = [];
-    const group3Cells: vscode.Uri[] = [];
-    
-    // Track if the active notebook document has available groups for the top level menu commands
-    // as we only want those to be enable if there is something in the active document to run
-    let activeGroup1 = false;
-    let activeGroup2 = false;
-    let activeGroup3 = false;
+    const group1Cells: Set<vscode.Uri> = new Set<vscode.Uri>();
+    const group2Cells: Set<vscode.Uri> = new Set<vscode.Uri>();
+    const group3Cells: Set<vscode.Uri> = new Set<vscode.Uri>();
 
+    // Groups for what documents have any cells in a group active
+    const group1Documents: Set<vscode.Uri> = new Set<vscode.Uri>();
+    const group2Documents: Set<vscode.Uri> = new Set<vscode.Uri>();
+    const group3Documents: Set<vscode.Uri> = new Set<vscode.Uri>();
+    
     // Scan visible notebooks
-    vscode.window.visibleNotebookEditors.forEach((notebookEditor) => {
-        notebookEditor.notebook.getCells().forEach((cell) => {
+    vscode.workspace.notebookDocuments.forEach((notebookDocument) => {
+        notebookDocument.getCells().forEach((cell) => {
             // Check each cell for group membership and assign it to any group buckets
             const cellGroups = getCellRunGroupMetadata(cell);
 
             if (cellGroups.includes(RunGroup.one.toString())) {
-                group1Cells.push(cell.document.uri);
-                if (notebookEditor === vscode.window.activeNotebookEditor) {
-                    // We want to know if any cells in the active editor are in groups to
-                    // enable non-cell specific UI
-                    activeGroup1 = true;
-                }
+                group1Cells.add(cell.document.uri);
+                group1Documents.add(cell.notebook.uri);
             }
             if (cellGroups.includes(RunGroup.two.toString())) {
-                group2Cells.push(cell.document.uri);
-                if (notebookEditor === vscode.window.activeNotebookEditor) {
-                    activeGroup2 = true;
-                }
+                group2Cells.add(cell.document.uri);
+                group2Documents.add(cell.notebook.uri);
             }
             if (cellGroups.includes(RunGroup.three.toString())) {
-                group3Cells.push(cell.document.uri);
-                if (notebookEditor === vscode.window.activeNotebookEditor) {
-                    activeGroup3 = true;
-                }
+                group3Cells.add(cell.document.uri);
+                group3Documents.add(cell.notebook.uri);
             }
         });
     });
 
     // Set the actual contexts
-    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupOneCells', group1Cells);
-    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupOneActive', activeGroup1);
-    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupTwoCells', group2Cells);
-    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupTwoActive', activeGroup2);
-    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupThreeCells', group3Cells);
-    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupThreeActive', activeGroup3);
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupOneCells', Array.from(group1Cells));
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupOneDocuments', Array.from(group1Documents));
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupTwoCells', Array.from(group2Cells));
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupTwoDocuments', Array.from(group2Documents));
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupThreeCells', Array.from(group3Cells));
+    vscode.commands.executeCommand('setContext', 'notebookRunGroups.groupThreeDocuments', Array.from(group3Documents));
 }

--- a/src/notebookRunGroups/documents.ts
+++ b/src/notebookRunGroups/documents.ts
@@ -14,6 +14,8 @@ export function registerDocuments(context: vscode.ExtensionContext) {
     updateContextKeys();
 }
 
+// IANHU: Not needed anymore?
+// IANHU: Perhaps replace with active document changed so we update the bigger UI items
 function selectionChanged(value: any) {
     updateContextKeys();
 }

--- a/src/notebookRunGroups/documents.ts
+++ b/src/notebookRunGroups/documents.ts
@@ -7,16 +7,14 @@ export function registerDocuments(context: vscode.ExtensionContext) {
     // Sign up for any document opens that we get
     context.subscriptions.push(vscode.workspace.onDidOpenNotebookDocument(documentOpen));
 
-    // Sign up for when the notebook editor selection changes
-    context.subscriptions.push(vscode.window.onDidChangeNotebookEditorSelection(selectionChanged));
+    // We need to update context keys when documents are swapped to update the top level toolbar commands
+    context.subscriptions.push(vscode.window.onDidChangeActiveNotebookEditor(notebookEditorChanged));
 
     // Update our initial context keys
     updateContextKeys();
 }
 
-// IANHU: Not needed anymore?
-// IANHU: Perhaps replace with active document changed so we update the bigger UI items
-function selectionChanged(value: any) {
+function notebookEditorChanged() {
     updateContextKeys();
 }
 

--- a/src/notebookRunGroups/enums.ts
+++ b/src/notebookRunGroups/enums.ts
@@ -2,6 +2,6 @@
 // Licensed under the MIT License.
 export enum RunGroup {
     one = 1,
-    two,
-    three
+    two = 2,
+    three = 3
 }

--- a/src/notebookRunGroups/enums.ts
+++ b/src/notebookRunGroups/enums.ts
@@ -2,6 +2,6 @@
 // Licensed under the MIT License.
 export enum RunGroup {
     one = 1,
-    two = 2,
-    three = 3
+    two,
+    three
 }

--- a/src/notebookRunGroups/util/cellMetadataHelpers.ts
+++ b/src/notebookRunGroups/util/cellMetadataHelpers.ts
@@ -27,6 +27,6 @@ export function updateCellRunGroupMetadata(cell: vscode.NotebookCell, newGroupVa
     // Perform our actual replace and edit
     const wsEdit = new vscode.WorkspaceEdit();
     const notebookEdit = vscode.NotebookEdit.updateCellMetadata(cell.index, newMetadata);
-    wsEdit.set(cell.document.uri, [notebookEdit]);
+    wsEdit.set(cell.notebook.uri, [notebookEdit]);
     vscode.workspace.applyEdit(wsEdit);
 }


### PR DESCRIPTION
Fixes: #50 and #47

## Previous
![image](https://user-images.githubusercontent.com/812783/184217523-053fe6ae-7a43-494c-8ac9-b8fc8bbfce45.png)
Note that the non-active, but visible cell reflects the icon state of the currently selected cell. Also side by side documents "share" execution icon state.

## Now
![UpdatedContextKeys2](https://user-images.githubusercontent.com/812783/184218034-8b2bd556-bc50-4abd-aed8-96343c4b04ac.gif)


- [x] Document level commands are not all the same, they are per document
- [x] Other visible cells don't "echo" the commands of the currently active cell
- [x] Command palette commands now only show and work on the active document
- [x] Document execute and command palette execute commands now disable if the document doesn't have anything in that run group.

Note: Also one small fix to allow for persisting of group state in documents due to an incorrect recent API update.