### PR TITLE
Bump versions for release and add basic release plan

### DIFF
--- a/.github/release_plan.md
+++ b/.github/release_plan.md
@@ -1,0 +1,7 @@
+- [ ] Review [Component Governance](https://dev.azure.com/monacotools/Monaco/_componentGovernance/193011) and resolve all High/Severe issues.
+- [ ] In package.json make sure to update the `version` and the `engine:vscode` properties to the values needed to support any new features. 
+- [ ] Update the `README.md` file with basic usage information for any new features added.
+- [ ] Trigger a manual run on the PowerToys [build definition](https://dev.azure.com/monacotools/Monaco/_build?definitionId=305).
+- [ ] From the triggered run, download the extension from the Artifacts.
+- [ ] Sniff test the built extension on VS Code and VS Code - Insiders.
+- [ ] Approve the publish step on the manually triggered run.

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
         "url": "https://github.com/Microsoft/vscode-jupyter-powertoys/issues"
     },
     "qna": "https://github.com/microsoft/vscode-jupyter-powertoys/discussions",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "engines": {
-        "vscode": "^1.67.0"
+        "vscode": "^1.70.0"
     },
     "extensionDependencies": [
         "ms-toolsai.jupyter"


### PR DESCRIPTION
I want to push a release with the contextkey fixes and a fix for the run group API changes. Just bumping versions and adding a very basic set of release steps (will add follow up to release_plan if I need to tweak anything for this release.